### PR TITLE
Allow removal of default status on a term

### DIFF
--- a/includes/taxonomy/alert-level.php
+++ b/includes/taxonomy/alert-level.php
@@ -180,6 +180,8 @@ function save_term_meta( int $term_id ) {
 		return;
 	}
 
+	// If the default checkbox has been selected, clear the previous default
+	// and set this term as the new default.
 	if ( isset( $_POST['alert_level_default'] ) ) {
 		clear_term_meta();
 
@@ -187,6 +189,12 @@ function save_term_meta( int $term_id ) {
 			$term_id,
 			'hp_alert_level_default',
 			true
+		);
+	} else {
+		// If the checkbox is not selected, assume the term is not the default.
+		delete_term_meta(
+			$term_id,
+			'hp_alert_level_default'
 		);
 	}
 }


### PR DESCRIPTION
When an alert expires, it sets its level back to a default alert level. If no alert level is set as the default, it clears the alert entirely.

Previously, it was not possible to clear the default alert level, so an expiring alert would always revert to the default level.

After this change, expiration works as expected.

Fixes #22