### PR TITLE
Add a field to capture alert title

### DIFF
--- a/includes/alerts.php
+++ b/includes/alerts.php
@@ -50,6 +50,17 @@ function register_meta() {
 				'type'          => 'integer',
 			]
 		);
+
+		register_post_meta(
+			$post_type,
+			'_hp_alert_title',
+			[
+				'show_in_rest'  => true,
+				'auth_callback' => '__return_true',
+				'single'        => true,
+				'type'          => 'string',
+			]
+		);
 	}
 }
 

--- a/includes/taxonomy/alert-level.php
+++ b/includes/taxonomy/alert-level.php
@@ -100,6 +100,13 @@ function enqueue_block_editor_assets() {
 		$asset_data['version'],
 		true
 	);
+
+	wp_enqueue_style(
+		'alert-level-box',
+		HP_ALERTS_PLUGIN_URL . '/build/index.css',
+		array(),
+		$asset_data['version']
+	);
 }
 
 /**

--- a/src/editor.css
+++ b/src/editor.css
@@ -1,0 +1,3 @@
+.hp-alert-settings > .components-base-control + * {
+	margin-top: 20px;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ const setAlertLevel = ( OriginalComponent ) => {
 			if ( 0 === Number( termID ) ) {
 				setMeta( {
 					_hp_alert_display_through: 0,
+					_hp_alert_title: '',
 				} );
 				setAlertLevels( [] );
 			} else {
@@ -104,9 +105,7 @@ const setAlertLevel = ( OriginalComponent ) => {
 							) }
 							label={ __( 'Title (optional)', 'hp-alerts' ) }
 							onChange={ ( value ) =>
-								setMeta( {
-									_hp_alert_title: value,
-								} )
+								setMeta( { _hp_alert_title: value } )
 							}
 							value={ title }
 						/>
@@ -125,9 +124,7 @@ const setAlertLevel = ( OriginalComponent ) => {
 							] }
 							onChange={ ( value ) => {
 								if ( 'no' === value ) {
-									setMeta( {
-										_hp_alert_display_through: 0,
-									} );
+									setMeta( { _hp_alert_display_through: 0 } );
 								} else {
 									// Convert to a unix timestamp before storing. Milliseconds!
 									const storeDate = Math.round(

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ import { addFilter } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
+import './editor.css';
+
 const setAlertLevel = ( OriginalComponent ) => {
 	return ( props ) => {
 		const { slug } = props;
@@ -85,7 +87,7 @@ const setAlertLevel = ( OriginalComponent ) => {
 		};
 
 		return (
-			<>
+			<div className="hp-alert-settings">
 				<SelectControl
 					label={ __( 'Alert level', 'hp-alerts' ) }
 					multiple={ false }
@@ -156,7 +158,7 @@ const setAlertLevel = ( OriginalComponent ) => {
 						__nextRemoveResetButton={ true }
 					/>
 				) }
-			</>
+			</div>
 		);
 	};
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import {
 	DateTimePicker,
 	RadioControl,
 	SelectControl,
+	TextareaControl,
 } from '@wordpress/components';
 import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -59,7 +60,10 @@ const setAlertLevel = ( OriginalComponent ) => {
 			slug
 		);
 		const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
-		const { _hp_alert_display_through: displayThrough } = meta;
+		const {
+			_hp_alert_display_through: displayThrough,
+			_hp_alert_title: title,
+		} = meta;
 
 		let displayThroughValue;
 
@@ -90,36 +94,51 @@ const setAlertLevel = ( OriginalComponent ) => {
 					value={ alertLevels }
 				/>
 				{ 0 < alertLevels.length && (
-					<RadioControl
-						label={ __( 'Alert expires', 'hp-alerts' ) }
-						selected={ displayThrough ? 'yes' : 'no' }
-						options={ [
-							{
-								label: __( 'Yes', 'hp-alerts' ),
-								value: 'yes',
-							},
-							{
-								label: __( 'No', 'hp-alerts' ),
-								value: 'no',
-							},
-						] }
-						onChange={ ( value ) => {
-							if ( 'no' === value ) {
+					<>
+						<TextareaControl
+							help={ __(
+								'Override the displayed title. The post title is displayed by default.',
+								'hp-alerts'
+							) }
+							label={ __( 'Title (optional)', 'hp-alerts' ) }
+							onChange={ ( value ) =>
 								setMeta( {
-									_hp_alert_display_through: 0,
-								} );
-							} else {
-								// Convert to a unix timestamp before storing. Milliseconds!
-								const storeDate = Math.round(
-									new Date().getTime() / 1000
-								);
-
-								setMeta( {
-									_hp_alert_display_through: storeDate,
-								} );
+									_hp_alert_title: value,
+								} )
 							}
-						} }
-					/>
+							value={ title }
+						/>
+						<RadioControl
+							label={ __( 'Alert expires', 'hp-alerts' ) }
+							selected={ displayThrough ? 'yes' : 'no' }
+							options={ [
+								{
+									label: __( 'Yes', 'hp-alerts' ),
+									value: 'yes',
+								},
+								{
+									label: __( 'No', 'hp-alerts' ),
+									value: 'no',
+								},
+							] }
+							onChange={ ( value ) => {
+								if ( 'no' === value ) {
+									setMeta( {
+										_hp_alert_display_through: 0,
+									} );
+								} else {
+									// Convert to a unix timestamp before storing. Milliseconds!
+									const storeDate = Math.round(
+										new Date().getTime() / 1000
+									);
+
+									setMeta( {
+										_hp_alert_display_through: storeDate,
+									} );
+								}
+							} }
+						/>
+					</>
 				) }
 				{ 0 < alertLevels.length && 0 !== displayThrough && (
 					<DateTimePicker


### PR DESCRIPTION
- Register meta and add a field for capturing alert title.
  - see #29.
- Improve spacing within the Alerts panel.
  - see #30.
  - There _should_ be a better way to do this...