### PR TITLE
Require custom-fields support on alert post types

### DIFF
--- a/includes/alerts.php
+++ b/includes/alerts.php
@@ -9,7 +9,7 @@ namespace HP\Alerts;
 
 use HP\Alerts\Taxonomy\AlertLevel;
 
-add_action( 'init', __NAMESPACE__ . '\register_meta' );
+add_action( 'init', __NAMESPACE__ . '\register_meta', 300 );
 add_action( 'updated_post_meta', __NAMESPACE__ . '\store_display_through', 10, 4 );
 add_action( 'added_post_meta', __NAMESPACE__ . '\store_display_through', 10, 4 );
 add_action( 'shutdown', __NAMESPACE__ . '\check_expired' );
@@ -32,7 +32,22 @@ function get_post_types(): array {
 	 *
 	 * @param string[] $post_types An array of post type keys.
 	 */
-	return apply_filters( 'hp_alerts_get_post_types', $post_types );
+	$post_types = apply_filters( 'hp_alerts_get_post_types', $post_types );
+
+	/**
+	 * Ensure the post type supports custom fields.
+	 *
+	 * If custom fields are not supported, and the custom fields interface is
+	 * displayed in the block editor, then the editor will crash when we load
+	 * the meta boxes. Strange things afoot!
+	 */
+	foreach ( $post_types as $key => $post_type ) {
+		if ( ! post_type_supports( $post_type, 'custom-fields' ) ) {
+			unset( $post_types[ $key ] );
+		}
+	}
+
+	return $post_types;
 }
 
 /**

--- a/includes/taxonomy/alert-level.php
+++ b/includes/taxonomy/alert-level.php
@@ -9,7 +9,7 @@ namespace HP\Alerts\Taxonomy\AlertLevel;
 
 use HP\Alerts;
 
-add_action( 'init', __NAMESPACE__ . '\register_taxonomy' );
+add_action( 'init', __NAMESPACE__ . '\register_taxonomy', 300 );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );
 add_filter( 'body_class', __NAMESPACE__ . '\filter_body_class' );
 add_action( get_slug() . '_edit_form_fields', __NAMESPACE__ . '\display_edit_form_fields' );


### PR DESCRIPTION
This is required for our meta controls to appear in the block editor *and* avoids crashing the editor on post types that do not support custom-fields when the custom fields interface is enabled

Fixes #48